### PR TITLE
Add 'R: Send' bound to Send impl of 'Decoder<R>'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ where
 
 unsafe impl<R> Send for Decoder<R>
 where
-        R: Read,
+        R: Read + Send,
 {
 }
 


### PR DESCRIPTION
resolves #4

Added `R: Send` bound to prevent unsound usage at compile time.

Thank you for reviewing this PR :+1: 